### PR TITLE
Lower log level severity from warning to info for OC installer when "multiple file" notice

### DIFF
--- a/src/util/file-finder.ts
+++ b/src/util/file-finder.ts
@@ -109,7 +109,7 @@ export async function findMatchingClient(source: string, client: InstallableClie
         archiveFilename = filteredClientFiles[1];
     }
     else if (filteredClientFiles.length > 1) {
-        ghCore.warning(`Multiple files were found for ${client} that matched the current OS and architecture: `
+        ghCore.info(`Notice: Multiple files were found for ${client} that matched the current OS and architecture: `
             + `${filteredClientFiles.join(", ")}. Selecting the first one.`);
     }
     else if (filteredClientFiles.length === 0) {


### PR DESCRIPTION
Using this-repo action like so:

      - name: Install oc from OpenShift Mirror
        uses: redhat-actions/openshift-tools-installer@v1
        with:
          oc: "latest" # Specifying "4.21.5" didn't changed the behaviour.

And getting this GitHubEE workflow annotation:
<img width="522" height="190" alt="image" src="https://github.com/user-attachments/assets/a7541978-4eba-41e4-9b09-51359ef50ac9" />


> Warning: Multiple files were found for oc that matched the current OS and architecture: openshift-client-linux-4.21.5.tar.gz, openshift-client-linux-amd64-rhel8-4.21.5.tar.gz, openshift-client-linux-amd64-rhel9-4.21.5.tar.gz, openshift-client-linux-arm64-4.21.5.tar.gz, openshift-client-linux-arm64-rhel8-4.21.5.tar.gz, openshift-client-linux-arm64-rhel9-4.21.5.tar.gz, openshift-client-linux-ppc64le-4.21.5.tar.gz, openshift-client-linux-ppc64le-rhel8-4.21.5.tar.gz, openshift-client-linux-ppc64le-rhel9-4.21.5.tar.gz, openshift-client-linux-s390x-rhel8-4.21.5.tar.gz, openshift-client-linux-s390x-rhel9-4.21.5.tar.gz. Selecting the first one.
Selecting openshift-client-linux-4.21.5.tar.gz

But everything works regardless. So would like to like to lower log message severity to information level to not have this annoying message everytime without ability to `#pragma warning disable` it.

It only should be warning if there is something user can do to solve that (user misconfiguration).