### PR TITLE
replace EOL ubuntu-20.04 runners with ubuntu-latest

### DIFF
--- a/.github/workflows/example_github.yml
+++ b/.github/workflows/example_github.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "windows-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "ubuntu-latest" ]
         cache: [ true, false ]
         # version: [ "latest", "1" ]
     runs-on: ${{ matrix.os }}
@@ -144,7 +144,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "ubuntu-latest" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/example_mirror.yml
+++ b/.github/workflows/example_mirror.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "windows-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "ubuntu-latest" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 
@@ -139,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "ubuntu-latest" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 
@@ -169,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "ubuntu-latest" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 
@@ -199,7 +199,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ "windows-latest", "ubuntu-20.04" ]   # Skip install on windows https://github.com/redhat-actions/openshift-tools-installer/issues/50
+        # os: [ "windows-latest", "ubuntu-latest" ]   # Skip install on windows https://github.com/redhat-actions/openshift-tools-installer/issues/50
         cache: [ true, false ]
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

- Replace `ubuntu-20.04` with `ubuntu-latest` in `example_mirror.yml` and `example_github.yml`
- GitHub [removed the `ubuntu-20.04` runner image on April 15, 2025](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/), causing all CI jobs using it to fail
- `ubuntu-latest` tracks the current LTS so these workflows stay functional without future manual bumps

Fixes #125