### PR TITLE
Add security hardening files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all files
+* @redhat-actions/maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please report them via [GitHub's private vulnerability reporting](https://github.com/redhat-actions/openshift-tools-installer/security/advisories/new).
+
+You can expect an initial response within 5 business days. We will work with you to understand the issue and address it promptly.
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| v1.x    | :white_check_mark: |
+| < v1    | :x:                |


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` with `@redhat-actions/maintainers` as default owner
- Add `SECURITY.md` with vulnerability reporting guidance
- Add `.github/dependabot.yml` for automated npm and GitHub Actions updates

Repository-level settings also applied (already live):
- Enabled secret scanning and push protection
- Set default workflow permissions to read-only
- Disabled force pushes on main branch

> **Note:** This PR targets `modernize/phase4-code-review` — merge that first.

## Test plan
- [ ] CODEOWNERS resolves to a valid GitHub team
- [ ] Dependabot creates update PRs after merge
- [ ] Security tab shows secret scanning enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)