### PR TITLE
Modernize CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,39 @@
 name: CI Checks
 on:
   push:
+    branches: [main]
+    paths-ignore: ['**.md']
   pull_request:
+    paths-ignore: ['**.md']
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Run ESLint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: npm ci
       - run: npm run lint
 
   check-dist:
     name: Check Distribution
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       BUNDLE_FILE: "dist/index.js"
       BUNDLE_COMMAND: "npm run bundle"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install
         run: npm ci
@@ -36,11 +46,11 @@ jobs:
 
   check-inputs-outputs:
     name: Check Input and Output enums
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       IO_FILE: ./src/generated/inputs-outputs.ts
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/example_github.yml
+++ b/.github/workflows/example_github.yml
@@ -1,10 +1,18 @@
 name: Install from GitHub Example
 on:
   push:
+    branches: [main]
   workflow_dispatch:
   pull_request:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   SOURCE: github
@@ -15,12 +23,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
+        os: [ "macos-latest", "windows-latest", "ubuntu-24.04" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ./
         id: install_clients
@@ -64,12 +72,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "windows-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "windows-latest", "ubuntu-24.04" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ./
         id: install_clients
@@ -113,13 +121,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "ubuntu-24.04" ]
         cache: [ true, false ]
         # version: [ "latest", "1" ]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ./
         id: install_clients
@@ -144,12 +152,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "ubuntu-24.04" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ./
         id: install_clients
@@ -175,10 +183,10 @@ jobs:
       matrix:
         # version: [ "latest", "1.4.1" ]
         cache: [ true, false ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ./
         id: install_clients
@@ -203,10 +211,10 @@ jobs:
       fail-fast: false
       matrix:
         cache: [ true, false ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ./
         id: install_clients

--- a/.github/workflows/example_mirror.yml
+++ b/.github/workflows/example_mirror.yml
@@ -1,10 +1,18 @@
 name: Install from Mirror Example
 on:
   push:
+    branches: [main]
   workflow_dispatch:
   pull_request:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   SOURCE: mirror
@@ -15,12 +23,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "windows-latest", "ubuntu-latest" ]
+        os: [ "macos-latest", "windows-latest", "ubuntu-24.04" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ./
         id: install_clients
@@ -61,12 +69,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "windows-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "windows-latest", "ubuntu-24.04" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ./
         id: install_clients
@@ -109,12 +117,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "ubuntu-24.04" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ./
         id: install_clients
@@ -139,12 +147,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "ubuntu-24.04" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ./
         id: install_clients
@@ -169,12 +177,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "macos-latest", "ubuntu-20.04" ]
+        os: [ "macos-latest", "ubuntu-24.04" ]
         cache: [ true, false ]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ./
         id: install_clients
@@ -199,12 +207,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ "windows-latest", "ubuntu-20.04" ]   # Skip install on windows https://github.com/redhat-actions/openshift-tools-installer/issues/50
+        # os: [ "windows-latest", "ubuntu-24.04" ]   # Skip install on windows https://github.com/redhat-actions/openshift-tools-installer/issues/50
         cache: [ true, false ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: ./
         id: install_clients

--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,6 +1,7 @@
 name: Link checker
 on:
   push:
+    branches: [main]
     paths:
       - '**.md'
   pull_request:
@@ -10,12 +11,19 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   markdown-link-check:
     name: Check links in markdown
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: true

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -1,35 +1,33 @@
-name: Vulnerability Scan with CRDA
+name: Security Scan
 on:
   push:
+    branches: [main]
   workflow_dispatch:
-  pull_request_target:
-    types: [ assigned, opened, synchronize, reopened, labeled, edited ]
+  pull_request:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
-jobs:
-  crda-scan:
-    runs-on: ubuntu-latest
-    name: Scan project vulnerability with CRDA
-    steps:
+permissions:
+  contents: read
 
-      - uses: actions/checkout@v2
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-24.04
+    name: npm audit
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '24'
 
-      - name: Install CRDA
-        uses: redhat-actions/openshift-tools-installer@v1
-        with:
-          source: github
-          github_pat: ${{ github.token }}
-          crda: "latest"
+      - name: Install dependencies
+        run: npm ci
 
-      - name: CRDA Scan
-        id: scan
-        uses: redhat-actions/crda@v1
-        with:
-          crda_key: ${{ secrets.CRDA_KEY }}
-          fail_on: never
+      - name: Run npm audit
+        run: npm audit


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` v2 → v4, `actions/setup-node` v2 → v4
- Add `permissions: contents: read` to all workflows
- Add concurrency groups with `cancel-in-progress`
- Replace EOL `ubuntu-20.04` / `ubuntu-latest` with `ubuntu-24.04`
- Replace deprecated CRDA scan with `npm audit`

> Stacked on #134 — merge that first.

## Test plan
- [ ] CI workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)