### PR TITLE
Fix stale comment on keepAlive workaround

### DIFF
--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -12,7 +12,8 @@ import {
 export const HttpClient = new http.HttpClient(
     undefined,
     undefined,
-    // Explicitl set keepAlive to false to workaround bug in node20 runtime
+    // Explicitly set keepAlive to false to workaround a bug introduced in Node 19+
+    // where the process hangs on exit with keepAlive enabled (now the default)
     // https://github.com/nodejs/node/issues/47228
     { keepAlive: false }
 );


### PR DESCRIPTION
## Summary
- Fix comment referencing "node20 runtime" — the bug is Node 19+ (still open)
- Fix "Explicitl" typo

> Stacked on #135 — merge that first.

## Test plan
- [ ] Comment-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)