### PR TITLE
Fix Dependabot PR CI failures and improve config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,20 @@ updates:
       # typescript-eslint does not support TS 7 yet (no programmatic API until TS 7.1)
       - dependency-name: "typescript"
         versions: [">=7.0.0"]
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps(dev)"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/dependabot_rebuild.yml
+++ b/.github/workflows/dependabot_rebuild.yml
@@ -1,0 +1,53 @@
+name: Rebuild Dist for Dependabot
+on:
+  push:
+    branches:
+      - 'dependabot/npm_and_yarn/**'
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+
+permissions:
+  contents: write
+
+jobs:
+  rebuild:
+    name: Rebuild dist bundle
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout Dependabot branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild bundle
+        run: npm run bundle
+
+      - name: Check for dist changes
+        id: diff
+        run: |
+          if git diff --quiet dist/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Bundle is already up to date."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Bundle has changed — will commit."
+          fi
+
+      - name: Commit and push updated dist
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dist/
+          git commit -m "Rebuild dist bundle for Dependabot update"
+          git push

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -30,4 +30,36 @@ jobs:
         run: npm ci
 
       - name: Run npm audit
-        run: npm audit
+        env:
+          # @actions/cache -> @actions/glob -> minimatch -> brace-expansion (no fix available)
+          IGNORED_GHSAS: "GHSA-mh99-v99m-4gvg"
+        run: |
+          npm audit --json > audit-result.json || true
+
+          remaining=$(node -e "
+            const fs = require('fs');
+            const ignored = process.env.IGNORED_GHSAS.split(',').map(s => s.trim());
+            const audit = JSON.parse(fs.readFileSync('audit-result.json', 'utf8'));
+            const vulns = audit.vulnerabilities || {};
+            let unignored = 0;
+            for (const [name, info] of Object.entries(vulns)) {
+              for (const via of (info.via || [])) {
+                if (typeof via === 'object' && via.url) {
+                  const ghsa = via.url.split('/').pop();
+                  if (!ignored.includes(ghsa)) {
+                    console.error('UNIGNORED: ' + name + ' (' + via.url + ')');
+                    unignored++;
+                  }
+                }
+              }
+            }
+            process.stdout.write(String(unignored));
+          ")
+
+          if [ "$remaining" -gt 0 ]; then
+            echo "::error::Found $remaining unignored vulnerabilities"
+            npm audit
+            exit 1
+          else
+            echo "All vulnerabilities are in the ignore list. Passing."
+          fi


### PR DESCRIPTION
## Summary

All 4 open Dependabot PRs fail CI due to two independent issues. This PR fixes both and improves the Dependabot configuration to reduce future noise.

- **npm audit fix**: The `@actions/cache` transitive dependency chain includes a vulnerable `brace-expansion` (GHSA-mh99-v99m-4gvg) with no upstream fix. Replace bare `npm audit` with a script that filters out known unfixable advisories while still catching new vulnerabilities.
- **Auto-rebuild dist**: Add a workflow that triggers on Dependabot npm branch pushes, rebuilds `dist/index.js`, and commits it back. Uses `push` trigger (not `pull_request_target`) for a safer security model.
- **Dependabot config**: Group minor/patch devDependency updates into single PRs and add commit-message prefixes (`deps:`, `deps(dev):`, `ci:`).

## Test plan

- [ ] Security Scan workflow passes on this PR (npm audit filter works)
- [ ] CI Checks pass on this PR
- [ ] After merge, verify the rebuild workflow triggers on the next Dependabot npm PR
- [ ] Verify grouped devDependency PRs appear on the next Dependabot run

🤖 Generated with [Claude Code](https://claude.com/claude-code)